### PR TITLE
rd single cluster

### DIFF
--- a/applicationset/examples/list-generator/list-example.yaml
+++ b/applicationset/examples/list-generator/list-example.yaml
@@ -6,9 +6,7 @@ spec:
   generators:
   - list:
       elements:
-      - cluster: engineering-dev
-        url: https://kubernetes.default.svc
-      - cluster: engineering-prod
+      - cluster: rancher-desktop
         url: https://kubernetes.default.svc
   template:
     metadata:
@@ -16,7 +14,7 @@ spec:
     spec:
       project: default
       source:
-        repoURL: https://github.com/argoproj/argo-cd.git
+        repoURL: https://github.com/carltonmason/argo-cd.git
         targetRevision: HEAD
         path: applicationset/examples/list-generator/guestbook/{{cluster}}
       destination:


### PR DESCRIPTION
updated list-example.yaml to refer to a single cluster with the name of rancher-desktop.

